### PR TITLE
Improving .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-build
-nbproject
+/build/
 /dist/
+/out/
+nbproject
+LeagueOfPokimon.iml


### PR DESCRIPTION
Added `out/` directory and `*.iml` file to be ignored by git. These are automatically generated by IntelliJ IDE (and pretty common for Java projects).

> This is also an example of a contribution to your repository directly from my fork.
> An example of what I showed in the live demo on my talk about OSS: https://youtu.be/GE5wR_SC_P4?t=1538